### PR TITLE
reglages navbar, seeds et sign-up

### DIFF
--- a/app/assets/stylesheets/components/_avatar.scss
+++ b/app/assets/stylesheets/components/_avatar.scss
@@ -1,6 +1,6 @@
 .avatar {
-  width: 40px;
-  height: 40px;
+  width: 50px;
+  height: 50px;
   border-radius: 50%;
 }
 .avatar-large {

--- a/app/assets/stylesheets/components/_buttons.scss
+++ b/app/assets/stylesheets/components/_buttons.scss
@@ -14,6 +14,7 @@
   color: red;
 }
 
+/*
 #btn-sign-up {
   background-color: #722329;
   border: 1px solid #A95D60;
@@ -25,3 +26,4 @@
 #btn-sign-up:hover {
   opacity: 1;
 }
+*/

--- a/app/assets/stylesheets/components/_forms.scss
+++ b/app/assets/stylesheets/components/_forms.scss
@@ -17,4 +17,5 @@
 
 .signup-pres {
   max-width: 40vw;
+  margin-right: 48px;
 }

--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -37,4 +37,10 @@
   margin-right: 16px;
 }
 
-
+#navbarSupportedContent {
+  ul {
+    display :flex;
+    justify-content : center;
+    align-items: center;
+  }
+}

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -35,8 +35,8 @@
                         input_html: { autocomplete: "new-password" } %>
           </div>
         </div>
-        <div class="form-actions d-flex justify-content-center bordeaux-bkg rounded">
-          <%= f.button :submit, "Sign up", { class:"white-text" } %>
+        <div class="form-actions d-flex justify-content-center btn-primary rounded">
+          <%= f.button :submit, "Sign up", { class:"text-white" } %>
         </div>
         <div class="d-flex justify-content-center">
           <%= render "devise/shared/links" %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -9,33 +9,28 @@
     <h1>The Lord of the Rent</h1>
   </div>
 
-
-
-
   <div class="collapse navbar-collapse" id="navbarSupportedContent">
     <ul class="navbar-nav mr-auto">
       <div class="nav-action-link">
         <li class="nav-item">
-          <%= link_to "#", class: "nav-item-logo" do %>
-            <%= image_tag "https://image.flaticon.com/icons/svg/10/10747.svg" %>
+          <%= link_to "#", class: "nav-item-logo nav-link" do %>
+            <div>
+              <%= image_tag "https://image.flaticon.com/icons/svg/10/10747.svg" %> Add a warrior
+            </div>
           <% end %>
-        </li>
-        <li class="nav-item">
-          <%= link_to "Add a warrior", "#", class: "nav-link" %>
         </li>
       </div>
       <div class="nav-action-link">
         <li class="nav-item">
-          <%= link_to "#", class: "nav-item-logo" do %>
-            <%= image_tag "https://image.flaticon.com/icons/svg/10/10652.svg" %>
+          <%= link_to "#", class: "nav-item-logo nav-link" do %>
+            <div>
+              <%= image_tag "https://image.flaticon.com/icons/svg/10/10652.svg" %> War chief
+            </div>
           <% end %>
         </li>
-        <li class="nav-item">
-          <%= link_to "War chief", "#", class: "nav-link" %>
-        </li>
       </div>
-      <li class="nav-item log" id="btn-sign-up">
-        <%= link_to "Sign-up", new_user_registration_path, class: "nav-link" %>
+      <li class="nav-item log">
+        <%= link_to "Sign-up", new_user_registration_path, class: "nav-link btn-primary text-white rounded" %>
       </li>
       <li class="nav-item log" id="btn-log-in">
         <%= link_to "Log-in", new_user_session_path, class: "nav-link" %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,7 +6,9 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
+Booking.destroy_all
 Warrior.destroy_all
+User.destroy_all
 
 30.times do
   User.create(first_name:Faker::Movies::LordOfTheRings.character, last_name:Faker::Movies::LordOfTheRings.character,email:Faker::Internet.email,password: 'jaures')
@@ -19,7 +21,7 @@ weapons = ["Bow", "Sword", "Axe", "Hammer", "Teeth", "Bare hands", "Magic"]
 
 5.times do
   warrior = Warrior.new(
-    nickname: Faker::Movies::LordOfTheRings.character,
+    nickname: Faker::Movies::LordOfTheRings.unique.character,
     race: races.sample,
     specialty: specialties.sample,
     user: User.all.sample,


### PR DESCRIPTION
Navbar: centrage en hauteur des liens, bouton sign-up avec texte blanc, regroupement icônes et liens en un seul bloc cliquable

Seeds:
Ajout de destroy_all sur les bookings (sinon conflit entre table warriors et table bookings)

Sign-up:
Réglages de margins et du bouton